### PR TITLE
Feature: Rename lib for legal reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
-# libjavasdl
-libjavasdl is a mapping of SDL2 APIs to Java. There are two goals for libjavasdl:
+LibJSDL
+=======
+
+LibJSDL is a mapping of SDL2 APIs to Java. There are two goals for LibJSDL:
 * Provide as direct of a mapping of SDL APIs as possible.
 * Provide as performant of a mapping as possible.
 
-Because of these goals there is a lot of room for Java niceties (Enums, encapulation, autoclosable, type-safety, etc.).
-These will be applied at some time int he future by wrapping the raw API.
+Because of these goals, there is a lot of room for Java niceties (enums, encapsulation, AutoClosable, type-safety, etc.) which are purposefully avoided.
+These can be applied by wrapping the raw API but it is not the aim of this project.
 
 ## Not Implemented
 * SDL_assert.h was not implemented.
 * SDL_SysWMinfo.h was not implemented.
 * Threads (SDL_thread.h, SDL_mutex.h, SDL_atomic.h) was not implemented.
 * Platform and CPU Information (SDL_platform.h, SDL_cpuinfo.h, SDL_endian.h, SDL_bits.h)
+*

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>net.mcclendo</groupId>
-    <artifactId>libjavasdl</artifactId>
+
+    <groupId>io.github</groupId>
+    <artifactId>libjsdl</artifactId>
     <version>2.0.8</version>
     <packaging>jar</packaging>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.resources.sourceEncoding>UTF-8</project.resources.sourceEncoding>
+        <java.version>1.8</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -58,4 +63,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>


### PR DESCRIPTION
Java is a registered trademark and the owner might not be happy of the library using it.
Therefore this merge request will rename it to non-conflicting LibJSDL (libjsdl).