### PR TITLE
Feature: Change maven name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ LibJSDL is a mapping of SDL2 APIs to Java. There are two goals for LibJSDL:
 * Provide as direct of a mapping of SDL APIs as possible.
 * Provide as performant of a mapping as possible.
 
-Because of these goals, there is a lot of room for Java niceties (enums, encapsulation, AutoClosable, type-safety, etc.) which are purposefully avoided.
-These can be applied by wrapping the raw API but it is not the aim of this project.
+Because of these goals, there is a lot of room for Java niceties (enums, encapsulation, AutoClosable, type-safety, etc.)
+which are intentionally avoided. These can be applied by wrapping the raw API,
+but it is outside the scope of this project.
 
 ## Not Implemented
 * SDL_assert.h was not implemented.
 * SDL_SysWMinfo.h was not implemented.
 * Threads (SDL_thread.h, SDL_mutex.h, SDL_atomic.h) was not implemented.
 * Platform and CPU Information (SDL_platform.h, SDL_cpuinfo.h, SDL_endian.h, SDL_bits.h)
-*

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github</groupId>
+    <groupId>io.github.libjsdl</groupId>
     <artifactId>libjsdl</artifactId>
     <version>2.0.8</version>
     <packaging>jar</packaging>


### PR DESCRIPTION
Changing Maven coordinates to io.github.libjsdl to be standards compliant.